### PR TITLE
Making it easier for people to know they need Entrez Direct.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -25,8 +25,8 @@ The FASTA files are in the `FASTA` directory and total ~8 MB. They are named `Ge
 	    KIR
 		    (17 files)
 	    SMA-6606.fa
-		    BRCA2-675.fa
-		    BRCA1-672.fa
+	    BRCA2-675.fa
+	    BRCA1-672.fa
 
 **Preview the collection contents**
 
@@ -53,6 +53,8 @@ In short:
     $ git clone <this repository>
     $ sh ./geneID_to_refseq_regions.sh ids.csv
 
+
+Note that the [Entrez Direct](http://www.ncbi.nlm.nih.gov/books/NBK179288/) tools must be available on your PATH.
 
 This describes the process I used to create these FASTA files.
 First, compile a list of GeneIDs for each region. I did this by hand in a google doc and the results are at in this repository: `ids.csv`.

--- a/geneID_to_refseq_regions.sh
+++ b/geneID_to_refseq_regions.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+
+# Die on errors
+set -e
+
 GENEIDFILE=$1
 NUMLINES=$(wc -l $GENEIDFILE | cut -d ' ' -f1)
 echo $NUMLINES


### PR DESCRIPTION
I didn't have Entrez Direct installed, so I was getting a bunch of empty files and no error messages.

I fixed the script to stop if the Entrez Direct tools don't work (or anything else bad happens) and added a note about the dependency.

Also, I was only running the scripts in the first place because the Arvados dataset seems to itself be a collection of empty files today. I know that that wasn't the case before, since I peeked at the FASTAs there and they had data. Has the dataset expired or something?
